### PR TITLE
DOCS: updated readme snes -> nes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
-# SNES-Emulator
+# NES-Emulator - 6502 CPU
 
-<https://wiki.superfamicom.org/>
+## Reference Guide
+http://www.obelisk.me.uk/6502/reference.html#BCS
 
-<https://bin.smwcentral.net/u/4842/regs.txt>
+## Manual
+http://archive.6502.org/datasheets/wdc_65816_programming_manual.pdf
+
+## Reference Implementation and Inspiration
 
 <https://bisqwit.iki.fi/source/nes.html>
+
+https://github.com/OneLoneCoder/olcNES


### PR DESCRIPTION
PR because I changed your initial commit.

README now specifies documentation/references/implementations for the 6502 rather than the 65186.